### PR TITLE
Potential fix for code scanning alert no. 16: Explicit returns mixed with implicit (fall through) returns

### DIFF
--- a/src/utils/formatters.py
+++ b/src/utils/formatters.py
@@ -5,7 +5,7 @@ def format_output(tool_name, output):
     elif tool_name == "dirsearch":
         return _parse_dirsearch(output)
     # ... other parsers
-
+    return None
 def _parse_nmap(data):
     # Extract open ports and services
     return {


### PR DESCRIPTION
Potential fix for [https://github.com/AKA-NETWORK/bughunter-cli/security/code-scanning/16](https://github.com/AKA-NETWORK/bughunter-cli/security/code-scanning/16)

To address the issue, an explicit return statement should be added to handle cases where no matching condition is found. This ensures that the function's behavior is clear and consistent, removing reliance on implicit returns. The best fix involves adding a return statement at the end of the function, returning either `None` or an appropriate default value based on the expected behavior of the code.

For the `format_output` function:
1. Add an explicit `return None` at the end of the function to handle cases where `tool_name` does not match any known parsers.
2. This change ensures that all paths within the function return a value explicitly, improving code readability and eliminating the implicit return.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
