### PR TITLE
Potential fix for code scanning alert no. 49: Incomplete URL substring sanitization

### DIFF
--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -40,19 +40,19 @@ def test_ai_analyze(mock_find_subdomains, mock_call_ai_api):
     # In a real scenario, you'd use a more robust regex or NLP to extract URLs from the prompt.
     # For the purpose of this test, we'll assume the subdomains are directly present.
     
-    # Check for blog.example.com
-    if "blog.example.com" in prompt_arg:
-        parsed_blog_url = urlparse(f"http://blog.example.com")
-        assert parsed_blog_url.hostname and is_valid_subdomain(parsed_blog_url.hostname, "blog.example.com")
-    else:
-        pytest.fail("blog.example.com not found in prompt_arg")
+    # Extract hostnames from the prompt_arg using regex and validate them
+    import re
+    hostname_pattern = r'\b([a-zA-Z0-9.-]+\.[a-zA-Z]{2,})\b'
+    found_blog = False
+    found_api = False
+    for match in re.findall(hostname_pattern, prompt_arg):
+        if is_valid_subdomain(match, "blog.example.com"):
+            found_blog = True
+        if is_valid_subdomain(match, "api.example.com"):
+            found_api = True
 
-    # Check for api.example.com
-    if "api.example.com" in prompt_arg:
-        parsed_api_url = urlparse(f"http://api.example.com")
-        assert parsed_api_url.hostname and is_valid_subdomain(parsed_api_url.hostname, "api.example.com")
-    else:
-        pytest.fail("api.example.com not found in prompt_arg")
+    assert found_blog, "blog.example.com not found or invalid in prompt_arg"
+    assert found_api, "api.example.com not found or invalid in prompt_arg"
 
     from urllib.parse import urlparse
     parsed_prompt = urlparse(prompt_arg)


### PR DESCRIPTION
Potential fix for [https://github.com/AKA-NETWORK/bughunter-cli/security/code-scanning/49](https://github.com/AKA-NETWORK/bughunter-cli/security/code-scanning/49)

To properly check for the presence of a subdomain in a URL or string, avoid substring matching. Instead, extract URLs from the prompt (if present), parse them, and check hostnames using robust logic (e.g., via `urlparse` and `is_valid_subdomain`). In this test, since the prompt may contain subdomain strings directly (not as part of URLs), the best fix is to iterate over all words/possible URLs in `prompt_arg`, use `urlparse` to extract hostnames, and use `is_valid_subdomain` for validation. If the prompt is known to always contain the subdomain as a URL, directly parse that URL and check the hostname. If not, a simple regex can be used to extract likely hostnames, which can then be validated. Avoid substring checks on the whole prompt.

Concrete changes:
- On lines 44 and 51, replace substring checks with logic that extracts hostnames from `prompt_arg` and validates them.
- If the prompt contains actual URLs, parse those URLs; if not, use regex to extract hostnames.
- Ensure no `"api.example.com" in prompt_arg` or `"blog.example.com" in prompt_arg` substring checks remain.

No new methods are required, but you may need to import `re` for regex hostname extraction.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
