### PR TITLE
Potential fix for code scanning alert no. 69: Unused import

### DIFF
--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -10,7 +10,7 @@ from click.testing import CliRunner
 from src.main import analyze
 from unittest.mock import patch, MagicMock
 import pytest
-from urllib.parse import urlparse
+
 
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/AKA-NETWORK/bughunter-cli/security/code-scanning/69](https://github.com/AKA-NETWORK/bughunter-cli/security/code-scanning/69)

To fix the problem, we should remove the redundant import of `urlparse` on line 13. This will eliminate the unnecessary duplication while preserving the functionality of the code, as the `urlparse` function is already imported on line 4.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
