### PR TITLE
Potential fix for code scanning alert no. 73: Unused import

### DIFF
--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 from click.testing import CliRunner
 from src.main import analyze
 from unittest.mock import patch, MagicMock
-import pytest
+
 
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/AKA-NETWORK/bughunter-cli/security/code-scanning/73](https://github.com/AKA-NETWORK/bughunter-cli/security/code-scanning/73)

To fix the problem, we will remove the redundant `import pytest` statement on line 12. This will eliminate the unused import and improve code readability without affecting the functionality of the code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
