### PR TITLE
Potential fix for code scanning alert no. 71: Unused import

### DIFF
--- a/src/utils/shell.py
+++ b/src/utils/shell.py
@@ -1,5 +1,4 @@
 import subprocess
-import click
 
 def run_shell_command(command: str):
     """Runs a shell command and returns its stdout, stderr, and return code."""


### PR DESCRIPTION
Potential fix for [https://github.com/AKA-NETWORK/bughunter-cli/security/code-scanning/71](https://github.com/AKA-NETWORK/bughunter-cli/security/code-scanning/71)

To fix the problem, simply remove the unused import statement for `click` from the file `src/utils/shell.py`. This involves deleting line 2 (`import click`). No other changes are necessary, as the rest of the code does not depend on `click`. This will clean up the code and remove the unnecessary dependency.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
